### PR TITLE
Allow publishers to make their verification status public (opt-in)

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -194,7 +194,7 @@ class PublishersController < ApplicationController
   end
 
   def publisher_create_params
-    params.require(:publisher).permit(:email, :brave_publisher_id, :name, :phone)
+    params.require(:publisher).permit(:email, :brave_publisher_id, :name, :phone, :show_verification_status)
   end
 
   def publisher_create_auth_token_params

--- a/app/views/publishers/new.html.slim
+++ b/app/views/publishers/new.html.slim
@@ -19,6 +19,11 @@
         .form-group
           = f.label(:phone, class: "control-label")
           = f.phone_field(:phone, class: "form-control", placeholder: "+1 888 555 9001", required: true)
+        .form-group
+          = f.label(:show_verification_status) do
+            = f.check_box(:show_verification_status, class: "control-checkbox")
+            text &nbsp;
+            = I18n.t("activerecord.attributes.publisher.show_verification_status")
         - if @should_throttle
           .form-group
             = recaptcha_tags

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
     attributes:
       publisher:
         brave_publisher_id: "Website domain"
+        show_verification_status: "Yes, please list my site in Brave's verified publisher list after verification"
     errors:
       models:
         publisher:

--- a/db/migrate/20170413222129_add_show_verification_status_to_publishers.rb
+++ b/db/migrate/20170413222129_add_show_verification_status_to_publishers.rb
@@ -1,0 +1,5 @@
+class AddShowVerificationStatusToPublishers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :publishers, :show_verification_status, :boolean
+  end
+end

--- a/db/migrate/20170418220835_change_show_verification_status_default_value_for_publishers.rb
+++ b/db/migrate/20170418220835_change_show_verification_status_default_value_for_publishers.rb
@@ -1,0 +1,5 @@
+class ChangeShowVerificationStatusDefaultValueForPublishers < ActiveRecord::Migration[5.0]
+  def change
+    change_column_default :publishers, :show_verification_status, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170413222129) do
+ActiveRecord::Schema.define(version: 20170418220835) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,7 +58,7 @@ ActiveRecord::Schema.define(version: 20170413222129) do
     t.string   "encrypted_authentication_token_iv"
     t.string   "verification_method"
     t.datetime "authentication_token_expires_at"
-    t.boolean  "show_verification_status"
+    t.boolean  "show_verification_status",          default: true
     t.index ["brave_publisher_id"], name: "index_publishers_on_brave_publisher_id", using: :btree
     t.index ["created_at"], name: "index_publishers_on_created_at", using: :btree
     t.index ["verification_token"], name: "index_publishers_on_verification_token", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170228002057) do
+ActiveRecord::Schema.define(version: 20170413222129) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 20170228002057) do
     t.string   "encrypted_authentication_token_iv"
     t.string   "verification_method"
     t.datetime "authentication_token_expires_at"
+    t.boolean  "show_verification_status"
     t.index ["brave_publisher_id"], name: "index_publishers_on_brave_publisher_id", using: :btree
     t.index ["created_at"], name: "index_publishers_on_created_at", using: :btree
     t.index ["verification_token"], name: "index_publishers_on_verification_token", using: :btree


### PR DESCRIPTION
Add checkbox to setup process allowing publishers to opt-in to making their verification status public

Fixes https://github.com/brave/publishers/issues/68

Auditors: @ayumi