### PR TITLE
Introduce footer with contact link

### DIFF
--- a/app/assets/stylesheets/partials/footer.sass
+++ b/app/assets/stylesheets/partials/footer.sass
@@ -1,0 +1,5 @@
+.footer
+  margin-top: 5rem
+  border-top: 1px solid #e5e5e5
+  padding: 1rem 0
+  color: $gray

--- a/app/views/application/_footer.html.slim
+++ b/app/views/application/_footer.html.slim
@@ -1,0 +1,8 @@
+.container
+  .row
+    .col-center.col-xs-12.col-md-8
+      .footer
+        .contact_support
+          span = I18n.t("static.footer_contact_leadin")
+          a href="mailto: #{Rails.application.secrets[:support_email]}"
+            = Rails.application.secrets[:support_email]

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -20,3 +20,5 @@ html
         = yield(:content_form_errors)
             
     = content_for?(:content) ? yield(:content) : yield
+
+    = render("footer")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -263,3 +263,4 @@ en:
     landing_login_body: "If you've already started or completed verification, we can email you a link to access your publisher account."
     landing_login_button: "Log in"
     landing_button: "Start verification"
+    footer_contact_leadin: "Questions? Contact "


### PR DESCRIPTION
This adds a footer with a contact link across the bottom of the content area:

![screen shot 2017-08-22 at 1 12 18 pm](https://user-images.githubusercontent.com/29122/29578113-17e0241e-873c-11e7-89d6-740ff14e433f.png)

I took a guess at the desired text and styling. Of course, I'm open to suggestions.

The email address that's displayed comes from the `:support_email` secret, as specified in #14.

[Resolves #14]