### PR TITLE
Email brave_publisher_id as link

### DIFF
--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -16,6 +16,11 @@ module PublishersHelper
     "https://#{publisher.brave_publisher_id}"
   end
 
+  def link_to_brave_publisher_id(publisher)
+    uri = URI::HTTP.build(host: publisher.brave_publisher_id)
+    link_to(publisher.brave_publisher_id, uri.to_s)
+  end
+
   def uphold_authorization_endpoint(publisher)
     Rails.application.secrets[:uphold_authorization_endpoint]
         .gsub('<UPHOLD_CLIENT_ID>', Rails.application.secrets[:uphold_client_id])

--- a/app/views/publisher_mailer/uphold_account_changed.html.slim
+++ b/app/views/publisher_mailer/uphold_account_changed.html.slim
@@ -6,7 +6,7 @@ p= I18n.t("publisher_mailer.uphold_account_changed.body")
 
 p
   strong.attribute= "#{Publisher.human_attribute_name("brave_publisher_id")}:"
-  = @publisher.brave_publisher_id
+  = link_to_brave_publisher_id(@publisher)
 
 p.hint
   span.attribute= "#{I18n.t("publisher_mailer.shared.contact_help")}:"

--- a/app/views/publisher_mailer/welcome.html.slim
+++ b/app/views/publisher_mailer/welcome.html.slim
@@ -8,7 +8,7 @@ p= I18n.t("publisher_mailer.welcome.intro")
 
 p
   strong.attribute= "#{Publisher.human_attribute_name("brave_publisher_id")}:"
-  = @publisher.brave_publisher_id
+  = link_to_brave_publisher_id(@publisher)
 
 h4
   strong.attribute= "#{I18n.t("publishers.contact_person")}:"

--- a/test/helpers/publishers_helper_test.rb
+++ b/test/helpers/publishers_helper_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class PublishersHelperTest < ActionView::TestCase
+  test "should render brave publisher id as a link" do
+    publisher = publishers(:default)
+    assert_dom_equal %{<a href="http://#{publisher.brave_publisher_id}">#{publisher.brave_publisher_id}</a>},
+                     link_to_brave_publisher_id(publisher)
+  end
+end

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -1,0 +1,20 @@
+# Preview all emails at http://localhost:3000/rails/mailers
+# Preview notification_mailer emails at http://localhost:3000/rails/mailers/notification_mailer
+class NotificationMailerPreview < ActionMailer::Preview
+
+  def publisher_form_retry
+    NotificationMailer.publisher_form_retry(Publisher.first)
+  end
+
+  def publisher_form_retry_internal
+    NotificationMailer.publisher_form_retry_internal(Publisher.first)
+  end
+
+  def publisher_payments_activated
+    NotificationMailer.publisher_payments_activated(Publisher.first)
+  end
+
+  def publisher_payments_activated_internal
+    NotificationMailer.publisher_payments_activated_internal(Publisher.first)
+  end
+end

--- a/test/mailers/previews/publisher_mailer_preview.rb
+++ b/test/mailers/previews/publisher_mailer_preview.rb
@@ -1,4 +1,38 @@
-# Preview all emails at http://localhost:3000/rails/mailers/publisher_mailer
+# Preview all emails at http://localhost:3000/rails/mailers
+# Preview publisher_mailer emails at http://localhost:3000/rails/mailers/publisher_mailer
 class PublisherMailerPreview < ActionMailer::Preview
 
+  def login_email
+    PublisherMailer.login_email(Publisher.first)
+  end
+
+  # TODO: Remove me. Deprecated.
+  def verification_deprecated
+    PublisherMailer.verification(Publisher.first)
+  end
+
+  # TODO: Remove me. Deprecated.
+  def verification_internal_deprecated
+    PublisherMailer.verification_internal(Publisher.first)
+  end
+
+  def verification_done
+    PublisherMailer.verification_done(Publisher.first)
+  end
+
+  def verification_done_internal
+    PublisherMailer.verification_done_internal(Publisher.first)
+  end
+
+  def welcome
+    PublisherMailer.welcome(Publisher.first)
+  end
+
+  def welcome_internal
+    PublisherMailer.welcome_internal(Publisher.first)
+  end
+
+  def uphold_account_changed
+    PublisherMailer.uphold_account_changed(Publisher.first)
+  end
 end

--- a/test/mailers/publisher_mailer_test.rb
+++ b/test/mailers/publisher_mailer_test.rb
@@ -1,7 +1,37 @@
 require 'test_helper'
 
 class PublisherMailerTest < ActionMailer::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "welcome" do
+    publisher = publishers(:default)
+    email = PublisherMailer.welcome(publisher)
+
+    # # Send the email, then test that it got queued
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal ['brave-publishers@localhost.local'], email.from
+    assert_equal [publisher.email], email.to
+
+    # check that the brave_publisher_id is rendered as a link
+    assert_match "Website domain:default.org ( http://default.org )", email.text_part.body.to_s
+    assert_match "href=\"http://#{publisher.brave_publisher_id}\"", email.html_part.body.to_s
+  end
+
+  test "uphold_account_changed" do
+    publisher = publishers(:default)
+    email = PublisherMailer.uphold_account_changed(publisher)
+
+    # # Send the email, then test that it got queued
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal ['brave-publishers@localhost.local'], email.from
+    assert_equal [publisher.email], email.to
+
+    # check that the brave_publisher_id is rendered as a link
+    assert_match "Website domain:default.org ( http://default.org )", email.text_part.body.to_s
+    assert_match "href=\"http://#{publisher.brave_publisher_id}\"", email.html_part.body.to_s
+  end
 end


### PR DESCRIPTION
Updates the uphold_account_changed and welcome emails to use HTML links to the `brave_publisher_id` .

Adds email previews for all emails in the system to aid in testing. These are not necessary, but they are helpful for quickly viewing the emails. As part of the rails testing framework they will not be available in production. 

I made an assumption that the link should use `http` and not `https` in order to match the probable behavior of the email clients' rendering of found links (for known top level domains).

There are a few emails that appear to not be used any more. I don't see an issue filed to remove them, though it should be considered.

Fixes #46 