### PR TITLE
Add locale string for `phone_normalized`

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
     attributes:
       publisher:
         brave_publisher_id: "Website domain"
+        phone_normalized: "Phone"
         show_verification_status: "Yes, please list my site in Brave's verified publisher list after verification"
     errors:
       models:


### PR DESCRIPTION
Adds a locale string for `phone_normalized` so the validation error field matches the display name for the field.

```
Phone normalized: is an invalid number
```
I encountered this field name mismatch on the `/publishers/new` endpoint. I hope this is a desirable change.