### PR TITLE
Handles protocols when registering a new publisher

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -223,6 +223,8 @@ class PublishersController < ApplicationController
     e.message
   rescue Faraday::Error
     I18n.t("activerecord.errors.models.publisher.attributes.brave_publisher_id.api_error_cant_normalize")
+  rescue URI::InvalidURIError
+    I18n.t("activerecord.errors.models.publisher.attributes.brave_publisher_id.invalid_uri")
   end
 
   def publisher_create_params

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -117,6 +117,11 @@ class Publisher < ApplicationRecord
       :brave_publisher_id,
       I18n.t("activerecord.errors.models.publisher.attributes.brave_publisher_id.api_error_cant_normalize")
     )
+  rescue URI::InvalidURIError
+    errors.add(
+      :brave_publisher_id,
+      I18n.t("activerecord.errors.models.publisher.attributes.brave_publisher_id.invalid_uri")
+    )
   end
 
   def verified_publisher_exists?

--- a/app/services/publisher_domain_normalizer.rb
+++ b/app/services/publisher_domain_normalizer.rb
@@ -3,7 +3,11 @@ class PublisherDomainNormalizer < BaseApiClient
   attr_reader :domain
 
   def initialize(domain:)
-    @domain = domain
+    # normalize domain by stripping off the protocol, it it exists,
+    # and checking if it parses as an http URL
+    host_and_path = domain.split(/:\/\//).last
+    URI.parse("http://#{host_and_path}")
+    @domain = host_and_path
   end
 
   def perform

--- a/app/services/publisher_login_link_emailer.rb
+++ b/app/services/publisher_login_link_emailer.rb
@@ -24,6 +24,9 @@ class PublisherLoginLinkEmailer
   rescue PublisherDomainNormalizer::DomainExclusionError, Faraday::Error
     @error = I18n.t("activerecord.errors.models.publisher.attributes.brave_publisher_id.api_error_cant_normalize")
     false
+  rescue URI::InvalidURIError
+    @error = I18n.t("activerecord.errors.models.publisher.attributes.brave_publisher_id.invalid_uri")
+    false
   end
 
   def find_publisher

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
               exclusion_list_error: "is on the Brave Publisher website exclusion list. For questions please contact "
               # TODO: Configurable email here
               taken: "Another person has already verified that website. If you have questions please contact support+publishers@brave.com."
+              invalid_uri: "invalid domain URI"
     models:
       publisher: "Publisher"
       publisher_legal_form: "Tax form"

--- a/test/services/publisher_domain_normalizer_test.rb
+++ b/test/services/publisher_domain_normalizer_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+require "webmock/minitest"
+
+class PublisherDomainNormalizerTest < ActiveJob::TestCase
+  test "when offline normalizes the domain" do
+    prev_api_ledger_offline = Rails.application.secrets[:api_ledger_offline]
+    Rails.application.secrets[:api_ledger_offline] = true
+
+    assert_equal "example.com", PublisherDomainNormalizer.new(domain: "https://example.com").perform
+    assert_equal "example2.com", PublisherDomainNormalizer.new(domain: "example2.com").perform
+
+    Rails.application.secrets[:api_ledger_offline] = prev_api_ledger_offline
+  end
+
+  test "when online normalizes the domain" do
+    prev_api_ledger_offline = Rails.application.secrets[:api_ledger_offline]
+    Rails.application.secrets[:api_ledger_offline] = false
+
+    stub_request(:get, /v2\/publisher\/identity\?url=http:\/\/example\.com/).
+        with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+        to_return(status: 200, body: "{\"protocol\":\"http:\",\"slashes\":true,\"auth\":null,\"host\":\"example.com\",\"port\":null,\"hostname\":\"foo-bar.com\",\"hash\":null,\"search\":\"\",\"query\":{},\"pathname\":\"/\",\"path\":\"/\",\"href\":\"http://foo-bar.com/\",\"TLD\":\"com\",\"URL\":\"http://foo-bar.com\",\"SLD\":\"foo-bar.com\",\"RLD\":\"\",\"QLD\":\"\",\"publisher\":\"example.com\"}", headers: {})
+
+    stub_request(:get, /v2\/publisher\/identity\?url=http:\/\/example2\.com/).
+        with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+        to_return(status: 200, body: "{\"protocol\":\"http:\",\"slashes\":true,\"auth\":null,\"host\":\"example2.com\",\"port\":null,\"hostname\":\"foo-bar.com\",\"hash\":null,\"search\":\"\",\"query\":{},\"pathname\":\"/\",\"path\":\"/\",\"href\":\"http://foo-bar.com/\",\"TLD\":\"com\",\"URL\":\"http://foo-bar.com\",\"SLD\":\"foo-bar.com\",\"RLD\":\"\",\"QLD\":\"\",\"publisher\":\"example2.com\"}", headers: {})
+
+    assert_equal "example.com", PublisherDomainNormalizer.new(domain: "https://example.com").perform
+    assert_equal "example2.com", PublisherDomainNormalizer.new(domain: "example2.com").perform
+
+    Rails.application.secrets[:api_ledger_offline] = prev_api_ledger_offline
+  end
+
+  test "raises exception with invalid url with protocol" do
+    assert_raises(URI::InvalidURIError) do
+      PublisherDomainNormalizer.new(domain: "https://bad url.com").perform
+    end
+  end
+
+  test "raises exception with invalid url without protocol" do
+    assert_raises(URI::InvalidURIError) do
+      PublisherDomainNormalizer.new(domain: "bad url.com").perform
+    end
+  end
+
+  test "when online handles normalization failures by raising DomainExclusionError" do
+    prev_api_ledger_offline = Rails.application.secrets[:api_ledger_offline]
+    Rails.application.secrets[:api_ledger_offline] = false
+
+    stub_request(:get, /v2\/publisher\/identity\?url=http:\/\/example3.com/).
+        with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+        to_return(status: 200, body: "{\"protocol\":\"http:\",\"slashes\":true,\"auth\":null,\"host\":\"example2.com\",\"port\":null,\"hostname\":\"foo-bar.com\",\"hash\":null,\"search\":\"\",\"query\":{},\"pathname\":\"/\",\"path\":\"/\",\"href\":\"http://foo-bar.com/\",\"TLD\":\"com\",\"URL\":\"http://foo-bar.com\",\"SLD\":\"foo-bar.com\",\"RLD\":\"\",\"QLD\":\"\"}", headers: {})
+
+    assert_raises(PublisherDomainNormalizer::DomainExclusionError) do
+      PublisherDomainNormalizer.new(domain: "https://example3.com").perform
+    end
+
+    Rails.application.secrets[:api_ledger_offline] = prev_api_ledger_offline
+  end
+end


### PR DESCRIPTION
When the publisher domain is being normalized any provided protocol is
stripped and replaced with `http` before being sent to
`ledger /v2/publisher/identity`.

Handles the case where a domain is malformed, such as including spaces,
before sending it to be normalized. This prevents sending domains to the
ledger which are not valid domains. It also adds a further degree of
consistency between the online and offline modes.

Adds testing for the above and basic mock testing for online mode.

Fixes #53