### PR TITLE
Fix flow for returning publishers who've completed Uphold verification

### DIFF
--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -49,12 +49,14 @@ module PublishersHelper
   end
 
   def publisher_next_step_path(publisher)
+    return home_publishers_path if publisher.uphold_complete?
+
     return verification_publishers_path if !publisher.verified?
+
     # ToDo: Polling page for exchanging uphold_code for uphold_access_parameters
     # return authorize_uphold_path if publisher.uphold_code && publisher.uphold_access_parameters.blank?
-    return verification_done_publishers_path if publisher.uphold_access_parameters.blank?
 
-    home_publishers_path
+    verification_done_publishers_path
   end
 
   # NOTE: Be careful! This link logs the publisher a back in.

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -85,15 +85,15 @@ class Publisher < ApplicationRecord
   end
 
   def uphold_complete?
-    self.uphold_verified || !self.uphold_access_parameters.blank?
+    self.uphold_verified || self.uphold_access_parameters.present?
   end
 
   def uphold_status
     if self.uphold_verified
       :verified
-    elsif !self.uphold_access_parameters.blank?
+    elsif self.uphold_access_parameters.present?
       :access_parameters_acquired
-    elsif !self.uphold_code.blank?
+    elsif self.uphold_code.present?
       :code_acquired
     else
       :unconnected

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -84,6 +84,10 @@ class Publisher < ApplicationRecord
     save!
   end
 
+  def uphold_complete?
+    self.uphold_verified || !self.uphold_access_parameters.blank?
+  end
+
   def uphold_status
     if self.uphold_verified
       :verified


### PR DESCRIPTION
Publishers were being directed to the `/publishers/verification_done` endpoint. After this fix they are directed to the `/publishers/home` endpoint.