### PR TITLE
Refactor JSON sent to wallet endpoint

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -59,7 +59,6 @@ default: &default
   uphold_client_secret: <%= ENV["UPHOLD_CLIENT_SECRET"] %>
   uphold_api_uri: <%= ENV["UPHOLD_API_URI"] %>
   uphold_scope: <%= ENV["UPHOLD_SCOPE"] %>
-  uphold_provider: <%= ENV["UPHOLD_PROVIDER"] %>
 
 development:
   <<: *default
@@ -83,7 +82,6 @@ test:
   uphold_client_secret: test_client_secret
   uphold_scope: a:read,b:read,c:deposit
   uphold_api_uri: "https://uphold-api.example.com"
-  uphold_provider: "uphold-api.example.com"
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/docs/publishers-secrets.example.sh
+++ b/docs/publishers-secrets.example.sh
@@ -39,5 +39,4 @@ export UPHOLD_CLIENT_ID="" # Client ID for registered Uphold application
 export UPHOLD_CLIENT_SECRET="" # Client secret for registered Uphold application
 export UPHOLD_AUTHORIZATION_ENDPOINT="https://sandbox.uphold.com/authorize/<UPHOLD_CLIENT_ID>?scope=<UPHOLD_SCOPE>&intention=signup&state=<STATE>"
 export UPHOLD_API_URI="https://api-sandbox.uphold.com" # the API endpoint for Uphold.
-export UPHOLD_PROVIDER="api-sandbox.uphold.com" # the Uphold API domain.
 export UPHOLD_SCOPE="cards:read,user:read,transactions:transfer:others"

--- a/test/jobs/upload_uphold_access_parameters_job_test.rb
+++ b/test/jobs/upload_uphold_access_parameters_job_test.rb
@@ -11,7 +11,15 @@ class UploadUpholdAccessParametersJobTest < ActiveJob::TestCase
     publisher.save!
 
     stub_request(:put, /publishers\/#{publisher.brave_publisher_id}\/wallet/)
-        .with(body: "{\"provider\": \"#{Rails.application.secrets[:uphold_provider]}\", \"parameters\": {\"access_token\":\"abc123\",\"token_type\":\"bearer\"}, \"verificationId\": \"#{publisher.id}\"}")
+        .with(body:
+          <<~BODY
+            {
+              "provider": "uphold", 
+              "parameters": {"access_token":"abc123","token_type":"bearer","server":"#{Rails.application.secrets[:uphold_api_uri]}"}, 
+              "verificationId": "#{publisher.id}"
+            }
+          BODY
+        )
 
     UploadUpholdAccessParametersJob.perform_now(publisher_id: publisher.id)
 


### PR DESCRIPTION
These changes are based on changes requested by @mrose17.

A `server` member has been added inside the `parameters` that come from Uphold.

The `UPHOLD_PROVIDER` env var is no longer needed, since we’re always going to just send `uphold` for this value.
