### PR TITLE
Use general publisher update endpoint for wallet updates

### DIFF
--- a/app/services/publisher_wallet_setter.rb
+++ b/app/services/publisher_wallet_setter.rb
@@ -28,7 +28,7 @@ class PublisherWalletSetter < BaseApiClient
           BODY
       request.headers["Authorization"] = api_authorization_header
       request.headers["Content-Type"] = "application/json"
-      request.url("/v2/publishers/#{publisher.brave_publisher_id}/wallet")
+      request.url("/v1/publishers/#{publisher.brave_publisher_id}")
     end
   end
 

--- a/test/jobs/upload_uphold_access_parameters_job_test.rb
+++ b/test/jobs/upload_uphold_access_parameters_job_test.rb
@@ -10,7 +10,7 @@ class UploadUpholdAccessParametersJobTest < ActiveJob::TestCase
     publisher.uphold_access_parameters = '{"access_token":"abc123","token_type":"bearer"}'
     publisher.save!
 
-    stub_request(:put, /publishers\/#{publisher.brave_publisher_id}\/wallet/)
+    stub_request(:put, /v1\/publishers\/#{publisher.brave_publisher_id}/)
         .with(body:
           <<~BODY
             {


### PR DESCRIPTION
As per @mrose17’s [comments](https://github.com/brave/publishers/issues/74#issuecomment-326138778), wallet updates can now be made via `PUT /v1/publishers/{publisher}`. 

The `/wallet` suffix has been deprecated.