### PR TITLE
Allow publishers to request statements from dashboard

### DIFF
--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -84,6 +84,8 @@ body[data-controller="publishers"]
         .email
           margin-right: 10px
           color: $gray
+      #statement_period
+        margin-right: 10px
 
   .hidden
     display: none

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -26,6 +26,7 @@ class PublishersController < ApplicationController
              verify)
   before_action :require_verified_publisher,
     only: %i(edit_payment_info
+             generate_statement
              home
              verification_done
              update
@@ -195,6 +196,17 @@ class PublishersController < ApplicationController
     path = after_sign_out_path_for(current_publisher)
     sign_out(current_publisher)
     redirect_to(path, notice: I18n.t("publishers.logged_out"))
+  end
+
+  def generate_statement
+    publisher = current_publisher
+    statement_period = params[:statement_period]
+    report_url = PublisherStatementGenerator.new(publisher: publisher, statement_period: statement_period.to_sym).perform
+    respond_to do |format|
+      format.json {
+        render(json: { reportURL: report_url }, status: 200)
+      }
+    end
   end
 
   private

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -68,4 +68,16 @@ module PublishersHelper
   def publisher_verification_dns_record(publisher)
     PublisherDnsRecordGenerator.new(publisher: publisher).perform
   end
+
+  def publisher_statement_periods
+    [
+      [t('publisher_statement_periods.past_7_days'), :past_7_days],
+      [t('publisher_statement_periods.past_30_days'), :past_30_days],
+      [t('publisher_statement_periods.this_month'), :this_month],
+      [t('publisher_statement_periods.last_month'), :last_month],
+      [t('publisher_statement_periods.this_year'), :this_year],
+      [t('publisher_statement_periods.last_year'), :last_year],
+      [t('publisher_statement_periods.all'), :all]
+    ]
+  end
 end

--- a/app/services/publisher_statement_generator.rb
+++ b/app/services/publisher_statement_generator.rb
@@ -1,0 +1,88 @@
+# Ask Eyeshade to generate a publisher statement.
+class PublisherStatementGenerator < BaseApiClient
+  attr_reader :publisher
+  attr_reader :statement_period
+
+  def initialize(publisher:, statement_period:)
+    @publisher = publisher
+    @statement_period = statement_period
+  end
+
+  def perform
+    return perform_offline if Rails.application.secrets[:api_eyeshade_offline]
+
+    # This raises when response is not 2xx.
+    response = connection.get do |request|
+      request.headers["Authorization"] = api_authorization_header
+      request.url("/v1/publishers/#{publisher.brave_publisher_id}/statement#{query_params}")
+    end
+
+    return JSON.parse(response.body)["reportURL"]
+  end
+
+  def perform_offline
+    fake_report = "/publishers/home#{query_params}"
+    Rails.logger.info("PublisherStatementGenerator eyeshade offline; generating fake report: #{fake_report}")
+    fake_report
+  end
+
+  def query_params
+    starting = statement_period_start
+    ending = statement_period_end
+
+    if starting || ending
+      qps = []
+      qps << "starting=#{starting.iso8601}" if starting
+      qps << "ending=#{ending.iso8601}" if ending
+      return "?#{qps.join('&')}"
+    end
+  end
+
+  private
+
+  def statement_period_start
+    case @statement_period
+    when :past_7_days
+      Date.today - 7
+    when :past_30_days
+      Date.today - 30
+    when :this_month
+      Date.today.beginning_of_month
+    when :last_month
+      (Date.today - 1.month).beginning_of_month
+    when :this_year
+      Date.today.beginning_of_year
+    when :last_year
+      (Date.today - 1.year).beginning_of_year
+    when :all
+      nil
+    end
+  end
+
+  def statement_period_end
+    case @statement_period
+    when :past_7_days
+      Date.today
+    when :past_30_days
+      Date.today
+    when :this_month
+      Date.today.end_of_month
+    when :last_month
+      (Date.today - 1.month).end_of_month
+    when :this_year
+      Date.today.end_of_year
+    when :last_year
+      (Date.today - 1.year).end_of_year
+    when :all
+      nil
+    end
+  end
+
+  def api_base_uri
+    Rails.application.secrets[:api_eyeshade_base_uri]
+  end
+
+  def api_authorization_header
+    "Bearer #{Rails.application.secrets[:api_eyeshade_key]}"
+  end
+end

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -24,20 +24,20 @@ javascript:
       }
     }
 
-    function submitForm(formId) {
+    function submitForm(formId, method, showSpinners) {
       var form = document.getElementById(formId);
       var options = {
         headers: {
           'Accept': 'application/json'
         },
         credentials: 'same-origin',
-        method: 'PATCH',
+        method: method,
         body: new FormData(form)
       };
-      showSpinner();
+      if (showSpinners) { showSpinner(); }
       return window.fetch(form.action, options)
         .then(function(response) {
-          hideSpinner();
+          if (showSpinners) { hideSpinner(); }
           if (response.status === 401) {
             // Force a page reload if the user is no longer authenticated.
             window.location.reload();
@@ -45,15 +45,41 @@ javascript:
           return response;
         })
         .catch(function(e) {
-          hideSpinner();
+          if (showSpinners) { hideSpinner(); }
           window.alert("An unexpected error occurred. Please try reloading this page.")
         });
+    }
+
+    function waitForReport(reportURL, delay, backoff, attempts) {
+      return new Promise(function(resolve, reject) {
+        if (attempts > 0) {
+          setTimeout(function() {
+            window.fetch(reportURL, { method: 'GET' })
+              .then(function(response) {
+                if (response.status === 200) {
+                  // report successfully fetched
+                  resolve(reportURL);
+                } else {
+                  // report could not be fetched, so try again
+                  return waitForReport(reportURL, delay + backoff, backoff, --attempts)
+                    .catch(reject);
+                }
+              }, function(e) {
+                // swallow exception and try again
+                return waitForReport(reportURL, delay + backoff, backoff, --attempts)
+                  .catch(reject);
+              });
+          }, delay);
+        } else {
+          throw new Error('Attempts exceeded!');
+        }
+      });
     }
 
     window.addEventListener('load', function() {
       var showVerificationStatusInput = document.getElementById('publisher_show_verification_status');
       showVerificationStatusInput.addEventListener('click', function(event) {
-        submitForm('update_show_verification_status');
+        submitForm('update_show_verification_status', 'PATCH', true);
       }, false);
 
       var showContact = document.getElementById('show_contact');
@@ -66,6 +92,10 @@ javascript:
 
       var editContact = document.getElementById('edit_contact');
       var cancelEditContact = document.getElementById('cancel_edit_contact');
+
+      var generateStatement = document.getElementById('generate_statement');
+      var generateStatementResult = document.getElementById('generate_statement_result');
+      var statementPeriod = document.getElementById('statement_period');
 
       editContact.addEventListener('click', function(event) {
         updateContactName.value = showContactName.innerText;
@@ -84,12 +114,42 @@ javascript:
 
       updateContact.addEventListener('submit', function(event) {
         event.preventDefault();
-        submitForm('update_contact')
+        submitForm('update_contact', 'PATCH', true)
           .then(function() {
             showContactName.innerText = updateContactName.value;
             showContactEmail.innerText = updateContactEmail.value;
             updateContact.style.display = 'none';
             showContact.style.display = 'block';
+          });
+      }, false);
+
+      statementPeriod.addEventListener('click', function(event) {
+        hideSpinner();
+        generateStatement.style.display = 'inline-block';
+        generateStatementResult.style.display = 'none';
+      }, false);
+
+      generateStatement.addEventListener('click', function(event) {
+        event.preventDefault();
+        showSpinner();
+        submitForm('statement_generator', 'PATCH', false)
+          .then(function(response) {
+            return response.json();
+          })
+          .then(function(json) {
+            generateStatement.style.display = 'none';
+            generateStatementResult.style.display = 'inline-block';
+            generateStatementResult.innerText = 'Generating ...';
+
+            return waitForReport(json.reportURL, 3000, 2000, 4);
+          })
+          .then(function(reportURL) {
+            hideSpinner();
+            generateStatementResult.innerHTML = '<a href="' + reportURL + '">View report</a>';
+          })
+          .catch(function() {
+            hideSpinner();
+            generateStatementResult.innerText = 'We will email you a link when your report is ready.'
           });
       }, false);
 
@@ -133,13 +193,22 @@ div#cssload-pgloading style="display: none"
         = " "
         span.approximate-hint.link-hint= I18n.t("publishers.balance_pending_approximate")
 
-      h4= I18n.t("publishers.contact_person")
+      h4= t("publishers.publisher_statements")
+      .attribute-value.statements
+        = form_for(current_publisher, url: generate_statement_publishers_path, html: {id: "statement_generator"}) do |f|
+          .form-group
+            = select_tag(:statement_period, options_for_select(publisher_statement_periods))
+            a#generate_statement href="#"
+              = t("shared.generate")
+            span#generate_statement_result
+
+      h4= t("publishers.contact_person")
       .attribute-value.contact-person
         div#show_contact
           span.name#show_contact_name= current_publisher.name
           span.email#show_contact_email= current_publisher.email
           a#edit_contact href="#"
-            = "Edit"
+            = t("shared.edit")
         = form_for(current_publisher, url: publishers_path, html: { id: "update_contact", class: "in-place-edit", style: "display: none" }) do |f|
           .form-group
             = f.label(:name, class: "control-label")
@@ -150,7 +219,7 @@ div#cssload-pgloading style="display: none"
           .button.form-group
             = f.submit(I18n.translate("shared.update"), class: "btn btn-primary")
             a#cancel_edit_contact href="#"
-              = "Cancel"
+              = t("shared.cancel")
 
       = form_for(current_publisher, url: publishers_path, html: { id: "update_show_verification_status" }) do |f|
         .form-group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,6 +83,7 @@ en:
     new_auth_token_wrong_email_publisher_verified: "Email doesn't match the publisher verification. Try leaving email blank to use the most recent email."
     new_header: "Publisher contact information"
     not_verified: "Unverified"
+    publisher_statements: "Publisher statements"
     status: "Status"
     status_to_receive_payments: "To receive payments you need to:"
     status_can_receive_funds: "You are fully setup to receive Brave Payments."
@@ -184,15 +185,26 @@ en:
       private_email_notice: "NOTE: This email contains a private access link. Anyone with it can manage private publisher info, including payment information. Before forwarding this email, ensure you trust the recipient."
       subject: "[%{brave_publisher_id}] Brave Publisher registration"
       title: "Publisher registration"
+  publisher_statement_periods:
+    past_7_days: "Past 7 days"
+    past_30_days: "Past 30 days"
+    this_month: "This month"
+    last_month: "Last month"
+    this_year: "This year"
+    last_year: "Last year"
+    all: "All"
   recaptcha:
     errors:
       recaptcha_unreachable: "reCAPTCHA server timeout; please try again."
       verification_failed: "reCAPTCHA verification failed; please try again."
   shared:
     api_error: "Your request couldn't be processed due to an API error."
+    cancel: "Cancel"
+    edit: "Edit"
     error: "Error"
     error_body: "Oops, sorry about that. You can try to refresh the page or return to"
     error_contact: "For assistance please contact us at: %{support_email}"
+    generate: "Generate"
     save_and_continue: "Save and continue"
     update: "Update"
   static:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
       get :uphold_verified
       patch :verify
       patch :update
+      patch :generate_statement
     end
   end
   devise_for :publishers

--- a/test/services/publisher_statement_generator_test.rb
+++ b/test/services/publisher_statement_generator_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+require "webmock/minitest"
+
+class PublisherStatementGeneratorTest < ActiveJob::TestCase
+  test "when offline returns a dummy link with accurate query params" do
+    prev_offline = Rails.application.secrets[:api_eyeshade_offline]
+    Rails.application.secrets[:api_eyeshade_offline] = true
+
+    publisher = publishers(:verified)
+    result = PublisherStatementGenerator.new(publisher: publisher, statement_period: :past_7_days).perform
+
+    assert_equal "/publishers/home?starting=#{(Date.today - 7).iso8601}&ending=#{Date.today.iso8601}", result
+
+    Rails.application.secrets[:api_eyeshade_offline] = prev_offline
+  end
+
+  test "when online returns the reportURL returned by eyeshade" do
+    prev_offline = Rails.application.secrets[:api_eyeshade_offline]
+    Rails.application.secrets[:api_eyeshade_offline] = false
+
+    stub_request(:get, /v1\/publishers\/verified\.org\/statement/).
+        with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+        to_return(status: 200, body: "{\"reportURL\":\"example.com/fake-report\"}", headers: {})
+
+    publisher = publishers(:verified)
+    result = PublisherStatementGenerator.new(publisher: publisher, statement_period: :all).perform
+    assert_equal "example.com/fake-report", result
+
+    Rails.application.secrets[:api_eyeshade_offline] = prev_offline
+  end
+
+  test "generates starting / ending query params" do
+    publisher = publishers(:verified)
+
+    # TODO: Consider testing with TimeCop
+
+    generator = PublisherStatementGenerator.new(publisher: publisher, statement_period: :past_7_days)
+    assert_equal "?starting=#{(Date.today - 7).iso8601}&ending=#{Date.today.iso8601}", generator.query_params
+
+    generator = PublisherStatementGenerator.new(publisher: publisher, statement_period: :past_30_days)
+    assert_equal "?starting=#{(Date.today - 30).iso8601}&ending=#{Date.today.iso8601}", generator.query_params
+
+    generator = PublisherStatementGenerator.new(publisher: publisher, statement_period: :this_month)
+    assert_equal "?starting=#{(Date.today.beginning_of_month).iso8601}&ending=#{Date.today.end_of_month.iso8601}", generator.query_params
+
+    generator = PublisherStatementGenerator.new(publisher: publisher, statement_period: :last_month)
+    assert_equal "?starting=#{((Date.today - 1.month).beginning_of_month).iso8601}&ending=#{(Date.today - 1.month).end_of_month.iso8601}", generator.query_params
+
+    generator = PublisherStatementGenerator.new(publisher: publisher, statement_period: :this_year)
+    assert_equal "?starting=#{Date.today.beginning_of_year.iso8601}&ending=#{Date.today.end_of_year.iso8601}", generator.query_params
+
+    generator = PublisherStatementGenerator.new(publisher: publisher, statement_period: :last_year)
+    assert_equal "?starting=#{((Date.today - 1.year).beginning_of_year).iso8601}&ending=#{(Date.today - 1.year).end_of_year.iso8601}", generator.query_params
+
+    generator = PublisherStatementGenerator.new(publisher: publisher, statement_period: :all)
+    assert_equal nil, generator.query_params
+  end
+end


### PR DESCRIPTION
As described in #74, publishers can now request reports be generated from their dashboard.

A `select` control is provided to choose a period, and a `Generate` link is used to invoke an Ajax call to a new `generate_statement` endpoint. This endpoint invokes the new `PublisherStatementGenerator` service, which requests a report URL from eyeshade.

The report URL that’s returned will be polled periodically to see if it exists (i.e. 200 is returned). Polling is done every 3s with a 2s backoff period. Four attempts are made. All settings can be tweaked easily.

If the report has been generated, a link will be presented to view it.

If the report is not generated during the polling period, the user is told that a link will be emailed when the report is ready.

---

Notes:

_Differences from #74_: Instead of the options `Month-to-date` and `Year-to-date`, the options `This month` and `This year` are used. These seem to flow nicely with the other options, but obviously could be changed to match the requested text.

_Testing_: We could optionally introduce the gem TimeCop to more thoroughly test the periods that are displayed. And again, we could use Capybara to more thoroughly test the client-side interactions.