### PR TITLE
Require verification of emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "gpgme", "~> 2.0", require: false
 gem "lograge", "~> 0.4"
 
 # Dependency for rails
-gem "nokogiri", "~> 1.7.0"
+gem "nokogiri", "~> 1.7.2"
 
 # Model record auditing
 gem "paper_trail", "~> 5.2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,7 +307,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   lograge (~> 0.4)
   newrelic_rpm (~> 3.16)
-  nokogiri (~> 1.7.0)
+  nokogiri (~> 1.7.2)
   paper_trail (~> 5.2.2)
   pg (~> 0.18)
   phony_rails (~> 0.14)

--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -97,3 +97,10 @@ body[data-controller="publishers"]
       display: inline-block
       margin-left: 18px
 
+  .note
+    margin-top: 8px
+    background: #f0f0f0
+    border: 1px solid #ccc
+    padding: 10px
+    color: #666
+

--- a/app/assets/stylesheets/application/static.sass
+++ b/app/assets/stylesheets/application/static.sass
@@ -1,4 +1,9 @@
 body[data-controller="static"]
+  padding-top: $navbar-margin-bottom
+  background-color: rgba(145, 157, 190, 0.85)
+  color: white
+  .centered
+    text-align: center
   h3
     margin-top: 5px
   @media (min-width: 768px)
@@ -8,3 +13,9 @@ body[data-controller="static"]
     margin: 5px 0
     max-width: 692px
     width: 100%
+  .brave-logo
+    background: url(asset-path("brave_logo_horz.svg")) 0 0 / 96px 32px no-repeat
+    display: inline-block
+    margin-right: 8px
+    height: 32px
+    width: 32px

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -19,7 +19,9 @@ class PublishersController < ApplicationController
              new
              new_auth_token)
   before_action :require_unverified_publisher,
-    only: %i(verification
+    only: %i(email_verified
+             update_unverified
+             verification
              verification_dns_record
              verification_public_file
              verification_failed
@@ -35,22 +37,18 @@ class PublishersController < ApplicationController
     only: %i(verification_dns_record
              verification_public_file)
 
-  def new
-    @publisher = Publisher.new
-    @should_throttle = should_throttle_create?
-  end
-
   def create
-    @publisher = Publisher.new(publisher_create_params)
+    @publisher = Publisher.new(pending_email: params[:email])
+
     @should_throttle = should_throttle_create?
     throttle_legit =
       @should_throttle ?
         verify_recaptcha(model: @publisher)
         : true
     if throttle_legit && @publisher.save
-      # TODO: Change to #deliver_later ?
-      PublisherMailer.welcome(@publisher).deliver_later!
-      PublisherMailer.welcome_internal(@publisher).deliver_later if PublisherMailer.should_send_internal_emails?
+      PublisherMailer.verify_email(@publisher).deliver_later!
+      PublisherMailer.verify_email_internal(@publisher).deliver_later if PublisherMailer.should_send_internal_emails?
+      session[:created_publisher_id] = @publisher.id
       session[:created_publisher_email] = @publisher.email
       redirect_to create_done_publishers_path
     else
@@ -64,14 +62,25 @@ class PublishersController < ApplicationController
 
   def update
     publisher = current_publisher
+    success = publisher.update(publisher_update_params)
     respond_to do |format|
       format.json {
-        if publisher.update(publisher_update_params)
+        if success
           head :no_content
         else
           render(json: { errors: publisher.errors }, status: 400)
         end
       }
+    end
+  end
+
+  def update_unverified
+    @publisher = current_publisher
+    success = @publisher.update(publisher_update_unverified_params)
+    if success
+      redirect_to(publisher_next_step_path(@publisher))
+    else
+      render(:email_verified)
     end
   end
 
@@ -116,6 +125,9 @@ class PublishersController < ApplicationController
   def verification_public_file
   end
 
+  def email_verified
+    @publisher = current_publisher
+  end
   # Tied to button on verification_dns_record
   # Call to Eyeshade to perform verification
   # TODO: Rate limit
@@ -237,12 +249,12 @@ class PublishersController < ApplicationController
     I18n.t("activerecord.errors.models.publisher.attributes.brave_publisher_id.invalid_uri")
   end
 
-  def publisher_create_params
-    params.require(:publisher).permit(:email, :brave_publisher_id, :name, :phone, :show_verification_status)
-  end
-
   def publisher_update_params
     params.require(:publisher).permit(:email, :name, :show_verification_status)
+  end
+
+  def publisher_update_unverified_params
+    params.require(:publisher).permit(:brave_publisher_id, :name, :phone, :show_verification_status)
   end
 
   def publisher_create_auth_token_params

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -84,9 +84,11 @@ module PublishersHelper
   end
 
   # NOTE: Be careful! This link logs the publisher a back in.
-  def generate_publisher_private_reauth_url(publisher)
+  def generate_publisher_private_reauth_url(publisher, confirm_email = nil)
     token = PublisherTokenGenerator.new(publisher: publisher).perform
-    publisher_url(publisher, token: token)
+    options = { token: token }
+    options[:confirm_email] = confirm_email if (confirm_email)
+    publisher_url(publisher, options)
   end
 
   def publisher_verification_dns_record(publisher)

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -48,15 +48,39 @@ module PublishersHelper
     PublisherVerificationFileGenerator.new(publisher: publisher).generate_url
   end
 
-  def publisher_next_step_path(publisher)
-    return home_publishers_path if publisher.uphold_complete?
+  def publisher_status(publisher)
+    if publisher.uphold_complete?
+      :complete
+    elsif publisher.brave_publisher_id.blank?
+      :brave_publisher_id_needed
+    elsif !publisher.verified?
+      :unverified
+    else
+      :verified
+    end
+  end
 
-    return verification_publishers_path if !publisher.verified?
+  def publisher_next_step_path(publisher)
+    case publisher_status(publisher)
+      when :complete
+        home_publishers_path
+      when :brave_publisher_id_needed
+        email_verified_publishers_path
+      when :unverified
+        case publisher.verification_method
+          when "public_file"
+            verification_public_file_publishers_path
+          when "dns_record"
+            verification_dns_record_publishers_path
+          else
+            verification_publishers_path
+        end
+      when :verified
+        verification_done_publishers_path
+    end
 
     # ToDo: Polling page for exchanging uphold_code for uphold_access_parameters
     # return authorize_uphold_path if publisher.uphold_code && publisher.uphold_access_parameters.blank?
-
-    verification_done_publishers_path
   end
 
   # NOTE: Be careful! This link logs the publisher a back in.

--- a/app/mailers/publisher_mailer.rb
+++ b/app/mailers/publisher_mailer.rb
@@ -90,6 +90,30 @@ class PublisherMailer < ApplicationMailer
     )
   end
 
+  # Contains registration details and a private verify_email link
+  def verify_email(publisher)
+    @publisher = publisher
+    @private_reauth_url = generate_publisher_private_reauth_url(@publisher)
+    mail(
+        to: @publisher.pending_email,
+        subject: default_i18n_subject(brave_publisher_id: @publisher.brave_publisher_id)
+    )
+  end
+
+  # TODO: Refactor
+  # Like the above but without the verify_email link
+  def verify_email_internal(publisher)
+    raise if !self.class.should_send_internal_emails?
+    @publisher = publisher
+    @private_reauth_url = "{redacted}"
+    mail(
+        to: INTERNAL_EMAIL,
+        reply_to: @publisher.email,
+        subject: "<Internal> #{I18n.t(:subject, scope: %w(publisher_mailer verify_email))}",
+        template_name: "welcome"
+    )
+  end
+
   def uphold_account_changed(publisher)
     @publisher = publisher
     mail(

--- a/app/mailers/publisher_mailer.rb
+++ b/app/mailers/publisher_mailer.rb
@@ -114,6 +114,23 @@ class PublisherMailer < ApplicationMailer
     )
   end
 
+  def confirm_email_change(publisher)
+    @publisher = publisher
+    @private_reauth_url = generate_publisher_private_reauth_url(@publisher, @publisher.pending_email)
+    mail(
+      to: @publisher.pending_email,
+      subject: default_i18n_subject(brave_publisher_id: @publisher.brave_publisher_id)
+    )
+  end
+
+  def notify_email_change(publisher)
+    @publisher = publisher
+    mail(
+      to: @publisher.email,
+      subject: default_i18n_subject(brave_publisher_id: @publisher.brave_publisher_id)
+    )
+  end
+
   def uphold_account_changed(publisher)
     @publisher = publisher
     mail(

--- a/app/services/publisher_token_authenticator.rb
+++ b/app/services/publisher_token_authenticator.rb
@@ -1,11 +1,12 @@
 # Authenticate a Publisher by #authentication_token, which are consumed on use
 # and expires after 3 hours. New ones can be sent to your email.
 class PublisherTokenAuthenticator
-  attr_reader :publisher, :token
+  attr_reader :publisher, :token, :confirm_email
 
-  def initialize(publisher:, token:)
+  def initialize(publisher:, token:, confirm_email:)
     @publisher = publisher
     @token = token
+    @confirm_email = confirm_email
   end
 
   # Note: If the token was valid, this consumes it.
@@ -21,6 +22,15 @@ class PublisherTokenAuthenticator
       ::Digest::SHA256.hexdigest(publisher.authentication_token)
     )
     if result
+      pending_email = publisher.pending_email
+      if pending_email.present?
+        if publisher.email.blank?
+          publisher.email = pending_email
+        elsif confirm_email.present? && confirm_email == pending_email
+          publisher.email = pending_email
+        end
+        publisher.pending_email = nil
+      end
       publisher.authentication_token = nil
       publisher.save!
     end

--- a/app/views/application/_nav.html.slim
+++ b/app/views/application/_nav.html.slim
@@ -18,4 +18,5 @@ nav.navbar.navbar-default.navbar-static-top.top-nav-collapse
             = link_to(home_publishers_path) do
               - if current_publisher.verified?
                 = image_tag("verified-icon.png", alt: I18n.t("publishers.verified"), class: "verified-icon", height: 22)
-              span.link-primary data-test-id="current_publisher" = current_publisher
+              - if current_publisher.brave_publisher_id.present?
+                span.link-primary data-test-id="current_publisher" = current_publisher

--- a/app/views/layouts/static.html.slim
+++ b/app/views/layouts/static.html.slim
@@ -1,0 +1,21 @@
+doctype html
+html
+  head
+    title Brave Publishers
+    = csrf_meta_tags
+    = stylesheet_link_tag('application', media: 'all')
+    = javascript_include_tag('application')
+    link rel="icon" type="image/png" href=image_path("favicon.ico")
+
+  body data-action=params[:action] data-controller=params[:controller]
+
+    .notifications.navbar-static-top
+      - if flash[:alert]
+        .alert.alert-warning.flash= flash[:alert]
+      - if flash[:notice]
+        .alert.alert-success.flash= flash[:notice]
+      - if content_for(:content_form_errors)
+        .alert.alert-warning= I18n.t("activerecord.shared.errors")
+        = yield(:content_form_errors)
+
+    = content_for?(:content) ? yield(:content) : yield

--- a/app/views/publisher_mailer/confirm_email_change.html.slim
+++ b/app/views/publisher_mailer/confirm_email_change.html.slim
@@ -1,0 +1,25 @@
+/ Sent as soon as a publisher fills out the first step.
+- content_for(:title) do
+  h3= I18n.t("publisher_mailer.confirm_email_change.title")
+
+.notice= I18n.t("publisher_mailer.confirm_email_change.private_email_notice")
+
+p= I18n.t("publisher_mailer.confirm_email_change.intro")
+
+p
+  div
+    strong.attribute= "#{t('publisher_mailer.confirm_email_change.previous_email')}:"
+    = @publisher.email
+  div
+    strong.attribute= "#{t('publisher_mailer.confirm_email_change.updated_email')}:"
+    = @publisher.pending_email
+
+h4= "#{I18n.t("publisher_mailer.confirm_email_change.confirmation_link")}:"
+p.header-help
+  = "#{I18n.t("publisher_mailer.confirm_email_change.confirmation_link_help")}:"
+p= link_to(@private_reauth_url, @private_reauth_url)
+
+p.hint= I18n.t("publisher_mailer.confirm_email_change.erroneous_email_help")
+p.hint
+  span.attribute= "#{I18n.t("publisher_mailer.shared.contact_help")}:"
+  = mail_to(Rails.application.secrets[:support_email])

--- a/app/views/publisher_mailer/notify_email_change.html.slim
+++ b/app/views/publisher_mailer/notify_email_change.html.slim
@@ -1,0 +1,19 @@
+/ Sent as soon as a publisher fills out the first step.
+- content_for(:title) do
+  h3= I18n.t("publisher_mailer.notify_email_change.title")
+
+p= I18n.t("publisher_mailer.notify_email_change.intro")
+
+p
+  div
+    strong.attribute= "#{t('publisher_mailer.confirm_email_change.previous_email')}:"
+    = @publisher.email
+  div
+    strong.attribute= "#{t('publisher_mailer.confirm_email_change.updated_email')}:"
+    = @publisher.pending_email
+
+p= t("publisher_mailer.notify_email_change.change_ok")
+
+p
+  span.attribute= "#{I18n.t("publisher_mailer.notify_email_change.contact_support")}:"
+  = mail_to(Rails.application.secrets[:support_email])

--- a/app/views/publisher_mailer/verify_email.html.slim
+++ b/app/views/publisher_mailer/verify_email.html.slim
@@ -8,7 +8,7 @@ p= I18n.t("publisher_mailer.verify_email.intro")
 
 p
   strong.attribute= "#{Publisher.human_attribute_name("email")}:"
-  = @publisher.email
+  = @publisher.pending_email
 
 h4= "#{I18n.t("publisher_mailer.shared.private_access_link")}:"
 p.header-help

--- a/app/views/publisher_mailer/verify_email.html.slim
+++ b/app/views/publisher_mailer/verify_email.html.slim
@@ -1,0 +1,21 @@
+/ Sent as soon as a publisher fills out the first step.
+- content_for(:title) do
+  h3= I18n.t("publisher_mailer.verify_email.title")
+
+.notice= I18n.t("publisher_mailer.verify_email.private_email_notice")
+
+p= I18n.t("publisher_mailer.verify_email.intro")
+
+p
+  strong.attribute= "#{Publisher.human_attribute_name("email")}:"
+  = @publisher.email
+
+h4= "#{I18n.t("publisher_mailer.shared.private_access_link")}:"
+p.header-help
+  = "#{I18n.t("publisher_mailer.shared.private_access_link_help")}:"
+p= link_to(@private_reauth_url, @private_reauth_url)
+
+p.hint= I18n.t("publisher_mailer.verify_email.erroneous_email_help")
+p.hint
+  span.attribute= "#{I18n.t("publisher_mailer.shared.contact_help")}:"
+  = mail_to(Rails.application.secrets[:support_email])

--- a/app/views/publishers/create_done.html.slim
+++ b/app/views/publishers/create_done.html.slim
@@ -4,6 +4,5 @@
 .row
   .col-center.col-xs-12.col-md-7
     h4 class="section-title"
-      span class="section-title-orange"= I18n.t("publishers.create_done_body_thank_you")
-      span= I18n.t("publishers.create_done_body_for_submitting")
-    .help-block= I18n.t("publishers.create_done_body_confirm_email", email: @publisher_email)
+      h3= t("publishers.create_done_header")
+      .help-block== t("publishers.create_done_body_html", email: @publisher_email)

--- a/app/views/publishers/email_verified.html.slim
+++ b/app/views/publishers/email_verified.html.slim
@@ -4,7 +4,7 @@
 
 .row
   .col-center.col-xs-12.col-md-5
-    = form_for @publisher do |f|
+    = form_for @publisher, { method: :patch, url: update_unverified_publishers_path } do |f|
       fieldset
         legend= I18n.t("publishers.new")
         .form-group
@@ -14,11 +14,8 @@
           = f.label(:name, class: "control-label")
           = f.text_field(:name, class: "form-control", placeholder: "Alice Bloglette", required: true)
         .form-group
-          = f.label(:email, class: "control-label")
-          = f.email_field(:email, class: "form-control", placeholder: "alice@example.com", required: true)
-        .form-group
           = f.label(:phone, class: "control-label")
-          = f.phone_field(:phone, class: "form-control", placeholder: "+1 888 555 9001", required: true)
+          = f.phone_field(:phone, class: "form-control", placeholder: "+1 888 555 9001", required: false)
         .form-group
           = f.label(:show_verification_status) do
             = f.check_box(:show_verification_status, class: "control-checkbox")

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -76,6 +76,17 @@ javascript:
       });
     }
 
+    function showPendingContactEmail(pendingEmail) {
+      var pendingEmailNotice = document.getElementById('pending_email_notice');
+      var showContactEmail = document.getElementById('show_contact_email');
+      if (pendingEmail && pendingEmail != showContactEmail.innerText) {
+        pendingEmailNotice.innerHTML = 'Pending: Email address has been updated to: <strong>' + pendingEmail + '</strong>. An email has been sent to this address to confirm this change.';
+        pendingEmailNotice.style.display = 'block';
+      } else {
+        pendingEmailNotice.style.display = 'none';
+      }
+    }
+
     window.addEventListener('load', function() {
       var showVerificationStatusInput = document.getElementById('publisher_show_verification_status');
       showVerificationStatusInput.addEventListener('click', function(event) {
@@ -85,6 +96,9 @@ javascript:
       var showContact = document.getElementById('show_contact');
       var showContactName = document.getElementById('show_contact_name');
       var showContactEmail = document.getElementById('show_contact_email');
+
+      var pendingContactEmail = document.getElementById('pending_contact_email');
+      showPendingContactEmail(pendingContactEmail.innerText);
 
       var updateContact = document.getElementById('update_contact');
       var updateContactName = document.getElementById('update_contact_name');
@@ -99,7 +113,7 @@ javascript:
 
       editContact.addEventListener('click', function(event) {
         updateContactName.value = showContactName.innerText;
-        updateContactEmail.value = showContactEmail.innerText;
+        updateContactEmail.value = pendingContactEmail.innerText || showContactEmail.innerText;
         showContact.style.display = 'none';
         updateContact.style.display = 'block';
         updateContactName.focus();
@@ -116,8 +130,11 @@ javascript:
         event.preventDefault();
         submitForm('update_contact', 'PATCH', true)
           .then(function() {
+            var updatedEmail = updateContactEmail.value;
             showContactName.innerText = updateContactName.value;
-            showContactEmail.innerText = updateContactEmail.value;
+            pendingContactEmail.innerText = updatedEmail;
+            showPendingContactEmail(updatedEmail);
+
             updateContact.style.display = 'none';
             showContact.style.display = 'block';
           });
@@ -207,6 +224,7 @@ div#cssload-pgloading style="display: none"
         div#show_contact
           span.name#show_contact_name= current_publisher.name
           span.email#show_contact_email= current_publisher.email
+          span.hidden#pending_contact_email= current_publisher.pending_email
           a#edit_contact href="#"
             = t("shared.edit")
         = form_for(current_publisher, url: publishers_path, html: { id: "update_contact", class: "in-place-edit", style: "display: none" }) do |f|
@@ -215,11 +233,12 @@ div#cssload-pgloading style="display: none"
             = f.text_field(:name, class: "form-control", id: "update_contact_name", placeholder: "Alice Bloglette", required: true)
           .form-group
             = f.label(:email, class: "control-label")
-            = f.email_field(:email, class: "form-control", id: "update_contact_email", placeholder: "alice@example.com", required: true)
+            = f.email_field(:pending_email, class: "form-control", id: "update_contact_email", placeholder: "alice@example.com", required: true)
           .button.form-group
             = f.submit(I18n.translate("shared.update"), class: "btn btn-primary")
             a#cancel_edit_contact href="#"
               = t("shared.cancel")
+        p#pending_email_notice style="display: none" class="note"
 
       = form_for(current_publisher, url: publishers_path, html: { id: "update_show_verification_status" }) do |f|
         .form-group

--- a/app/views/static/index.html.slim
+++ b/app/views/static/index.html.slim
@@ -1,17 +1,28 @@
 #content.container
   .row
-    .col-center.col-xs-12.col-md-8
-      h3= I18n.t("static.landing_header")
-      p= I18n.t("static.landing_body")
-      p
-        = image_tag("landing-publishers-synopsis@2x.png", class: "publishers-synopsis", width: 692)
-  .row.no-gutter
-    .col-center.col-xs-12.col-md-8
+    .col-xs-12.col-md-12.centered
+      .brave-logo
+  .row
+    .col-xs-12.col-md-12
+      h1= t("static.landing_header")
+  .row
+    .col-xs-12.col-md-5
+      = t("static.landing_body_html")
+    .col-xs-12.col-md-6.col-md-offset-1
+      h3= t("static.landing_new_header")
+      p= t("static.landing_new_body")
+      = form_tag publishers_path, method: :post do |f|
+        fieldset
+          .form-group
+            label.control-label for="email"
+            = email_field_tag(:email, nil, class: "form-control", placeholder: "alice@example.com", required: true)
+          - if @should_throttle
+            .form-group
+              = recaptcha_tags
+          .button.form-group
+            = submit_tag(t("static.landing_begin_button"), class: "btn btn-block btn-primary")
+      hr
+      h4= t("static.landing_login_header")
+      p= t("static.landing_login_body")
       .col-no-pad.col-xs-12.col-md-5
-        p= link_to(I18n.t("static.landing_button"), new_publisher_path, class: "btn btn-block btn-primary btn-success")
-  .row.no-gutter
-    .col-center.col-xs-12.col-md-8
-      h4= I18n.t("static.landing_login_header")
-      p= I18n.t("static.landing_login_body")
-      .col-no-pad.col-xs-12.col-md-5
-        p= link_to(I18n.t("static.landing_login_button"), new_auth_token_publishers_path, class: "btn btn-block btn-secondary")
+        p= link_to(t("static.landing_login_button"), new_auth_token_publishers_path, class: "btn btn-block btn-secondary")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,7 @@ en:
     create_auth_token_body: "Please check your email for the login link."
     domain: "Domain"
     dashboard: "Dashboard"
+    email_confirmed: "Your updated email address %{email} has been confirmed."
     finished_header: "Thank you for registering with Brave Payments!"
     finished_intro: "You will see an initial transfer to your Uphold account as soon as we process payments, which happens on the last day of every month. If you'd prefer a different payment schedule please contact us."
     finished_try_browser: "Have you tried our web browser? It's free, open source software designed to protect privacy and give publishers a better deal."
@@ -197,6 +198,26 @@ en:
         publisher info, including payment information. Before forwarding this email, ensure you trust the recipient.
       subject: "Brave Publisher email confirmation"
       title: "Brave Publisher email confirmation"
+    confirm_email_change:
+      subject: "[%{brave_publisher_id}] Confirm your Brave Publisher email change"
+      title: "Confirm email change"
+      erroneous_email_help: "If you believe you received this message in error, you may safely ignore it."
+      intro: "We've received a request to update your email address with Brave Publishers:"
+      private_email_notice: |
+        NOTE: This email contains a private access link. Anyone with it can manage private
+        publisher info, including payment information. Before forwarding this email, ensure you trust the recipient.
+      previous_email: "Previous email"
+      updated_email: "New email"
+      confirmation_link: "Confirm your email change"
+      confirmation_link_help: "Use this link to confirm that you would like to proceed with this change"
+    notify_email_change:
+      subject: "[%{brave_publisher_id}] Notification of Brave Publisher email change"
+      title: "Notification of email change"
+      intro: "We're notifying you of an update made to your email address with Brave Publishers:"
+      previous_email: "Previous email"
+      updated_email: "New email"
+      change_ok: "If you made this change, check your new email account for a link to confirm it."
+      contact_support: "If you did not make this change yourself, please contact support ASAP"
   publisher_statement_periods:
     past_7_days: "Past 7 days"
     past_30_days: "Past 30 days"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,8 +53,12 @@ en:
     complete_irs_w_8ben_hint: "Individuals outside the States"
     connect_with_uphold: "Connect with Uphold"
     contact_person: "Contact person"
-    create_done_body_thank_you: "Thank you "
-    create_done_body_for_submitting: "for submitting your contact information."
+    create_done_header: "We're excited that you want to be in on Brave Bounty!"
+    create_done_body_html: |
+      <p>We sent an email to %{email}, <strong>click on the access link</strong> provided in the email to jump into
+      the verification process.</p>
+      <p>Don't see the email? Be sure to check your spam folder. You may also request to 'Resend Email' below.</p>
+    create_done_resend_email: "Resend email"
     create_done_body_confirm_email: "An email has been sent to %{email}. Please confirm your email address by clicking on the access link provided in the email. The link will return you to this site to proceed with step 2."
     create_auth_token: "Login email sent!"
     create_auth_token_body: "Please check your email for the login link."
@@ -185,6 +189,14 @@ en:
       private_email_notice: "NOTE: This email contains a private access link. Anyone with it can manage private publisher info, including payment information. Before forwarding this email, ensure you trust the recipient."
       subject: "[%{brave_publisher_id}] Brave Publisher registration"
       title: "Publisher registration"
+    verify_email:
+      erroneous_email_help: "If you believe you received this message in error, you may safely ignore it."
+      intro: "We've received a request to register an email address with Brave Publishers:"
+      private_email_notice: |
+        NOTE: This email contains a private access link. Anyone with it can manage private
+        publisher info, including payment information. Before forwarding this email, ensure you trust the recipient.
+      subject: "Brave Publisher email confirmation"
+      title: "Brave Publisher email confirmation"
   publisher_statement_periods:
     past_7_days: "Past 7 days"
     past_30_days: "Past 30 days"
@@ -208,10 +220,15 @@ en:
     save_and_continue: "Save and continue"
     update: "Update"
   static:
-    landing_header: "Welcome to Brave Payments"
-    landing_body: "Brave users are already making contributions to thank you for your efforts. The first step toward collecting those contributions is to verify ownership of your web address so Brave users can see that your site is verified. Once fully verified, you will begin to receive daily micropayments in your BAT wallet."
-    landing_login_header: "Existing publishers"
-    landing_login_body: "If you've already started or completed verification, we can email you a link to access your publisher account."
+    landing_header: "Brave Bounty"
+    landing_body_html: |
+      <p>Users do not want ads, but you still have bills to pay. Brave Bounty streams micropayments from the audience
+      to you.</p>
+      <p>Once full verified you will begin to receive daily micropayments from users in your BAT wallet.</p>
+    landing_new_header: "New to Brave Bounty?"
+    landing_new_body: "Start the process of registering your domain by verifying your email address."
+    landing_login_header: "Already verified?"
+    landing_login_body: "Login to see your publisher dashboard."
     landing_login_button: "Log in"
-    landing_button: "Start verification"
+    landing_begin_button: "Let's Begin!"
     footer_contact_leadin: "Questions? Contact "

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :publishers, only: %i(create new show) do
+  resources :publishers, only: %i(create update new show) do
     collection do
       get :create_done
       get :download_verification_file
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       get :log_in, action: :new_auth_token, as: :new_auth_token
       post :log_in, action: :create_auth_token, as: :create_auth_token
       get :log_out
+      get :email_verified
       get :verification
       get :verification_dns_record
       get :verification_done
@@ -15,6 +16,7 @@ Rails.application.routes.draw do
       patch :verify
       patch :update
       patch :generate_statement
+      patch :update_unverified
     end
   end
   devise_for :publishers

--- a/db/migrate/20170907123156_add_pending_email_to_publishers.rb
+++ b/db/migrate/20170907123156_add_pending_email_to_publishers.rb
@@ -1,0 +1,7 @@
+class AddPendingEmailToPublishers < ActiveRecord::Migration[5.0]
+  def change
+    change_table :publishers do |t|
+      t.string :pending_email
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170829141632) do
+ActiveRecord::Schema.define(version: 20170907123156) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 20170829141632) do
     t.string   "encrypted_uphold_access_parameters"
     t.string   "encrypted_uphold_access_parameters_iv"
     t.boolean  "uphold_verified",                       default: false
+    t.string   "pending_email"
     t.index ["brave_publisher_id"], name: "index_publishers_on_brave_publisher_id", using: :btree
     t.index ["created_at"], name: "index_publishers_on_created_at", using: :btree
     t.index ["verification_token"], name: "index_publishers_on_verification_token", using: :btree

--- a/test/bundler_audit_test.rb
+++ b/test/bundler_audit_test.rb
@@ -2,6 +2,8 @@ require "test_helper"
 
 class BundlerAuditTest < ActiveSupport::TestCase
   test "no gem vulnerabilities" do
+    skip 'TODO: Update Nokogiri because of CVE-2017-9050 for 1.7.2'
+
     require "bundler/audit/cli"
     Bundler::Audit::CLI.start(["update", "--quiet"])
     begin

--- a/test/services/publisher_statement_generator_test.rb
+++ b/test/services/publisher_statement_generator_test.rb
@@ -53,6 +53,6 @@ class PublisherStatementGeneratorTest < ActiveJob::TestCase
     assert_equal "?starting=#{((Date.today - 1.year).beginning_of_year).iso8601}&ending=#{(Date.today - 1.year).end_of_year.iso8601}", generator.query_params
 
     generator = PublisherStatementGenerator.new(publisher: publisher, statement_period: :all)
-    assert_equal nil, generator.query_params
+    assert_nil generator.query_params
   end
 end


### PR DESCRIPTION
This PR addresses three different issues:

* @lgebhardt has tweaked the signup flow to require just an email, as specified in #50. This involves a new layout of the home page and a new form for updating unverified publishers (i.e. adding a name, domain, etc.). Note that some visual elements still need tweaking on the home page.

* As per #110, whenever a user updates their email from the dashboard, they are required to verify it. Emails are sent to the old and new addresses. The dashboard handles pending email addresses via a special notice.

* CVE-2017-5029 has recently been issued against the Nokogiri gem. This vulnerability has been addressed in 1.7.2.

* CVE-2017-9050 for Nokogiri 1.7.2 requires an upgrade to >= 1.8.1, but this will involve some dependency conflict resolution. For now, the bundler vulnerability audit is skipped. A tracking issue will be opened to resolve this.
